### PR TITLE
fix: close italic tags

### DIFF
--- a/contents.html
+++ b/contents.html
@@ -330,11 +330,11 @@
       &nbsp; Speaker at SHIFT Business Webstival (27.10.2020), Online<br />
       <br />
       
-      <i>What Does Testing Mean Today?<i><br />
+      <i>What Does Testing Mean Today?</i><br />
       &nbsp; Panelist at BCS SIGiST (20.10.2020), Online<br />
       <br />
       
-      <i>Ensuring Excellent Overall Quality Dialogue<i><br />
+      <i>Ensuring Excellent Overall Quality Dialogue</i><br />
       &nbsp; Panelist at Scan Agile (21.9.2020), Online<br />
       <br />
       
@@ -671,7 +671,7 @@
       &nbsp; Facilitator at BTD Conference, Brussels, Belgium (20.5.2015)<br />
       <br />
       
-      <i>Test Cases and Testing (Testitapausten suunnittelu), </i>2-day course<i></i><br />
+      <i>Test Cases and Testing (Testitapausten suunnittelu), </i>2-day course</i></i><br />
       &nbsp;Trainer for Altom public course, Helsinki, Finland (22-23.4.2015)<br />
       <br />
       


### PR DESCRIPTION
Noticed that the `contents.html` page was having italic text styles for half of the page after a few unclosed `<i>` tags. This pull request adds the missing characters to make the page look as originally intended.

### Changes

- Close italic tags on the `contents.html`
